### PR TITLE
[#1] added updates and manual trigger

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,28 +1,56 @@
 name: Build and Push Docker Image
+
 on:
   push:
     branches:
-      - main  # Change this to your default branch
+      - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Docker image tag (e.g., latest, v1.2.3)
+        required: true
+        default: latest
+      platforms:
+        description: Target platforms
+        required: true
+        default: linux/amd64,linux/arm64
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      IMAGE: cleisonfmelo/postgres-pg-cron
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || 'latest' }}
+      PLATFORMS: ${{ github.event_name == 'workflow_dispatch' && inputs.platforms || 'linux/amd64,linux/arm64' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: cleisonfmelo/postgres-pg-cron:latest
+          tags: ${{ env.IMAGE }}:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing Docker images, adding support for manual workflow dispatch, improving flexibility, and updating action versions for better performance and security. The most important changes are grouped below.

**Workflow flexibility and manual triggers:**

* Added support for manual workflow dispatch with customizable Docker image tag and target platforms through new `workflow_dispatch` inputs.
* Introduced environment variables (`IMAGE`, `TAG`, `PLATFORMS`) to dynamically set image tags and platforms based on trigger type (push or manual dispatch).

**Modernization and best practices:**

* Updated Docker-related GitHub Actions to the latest major versions (`actions/checkout@v4`, `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, `docker/build-push-action@v5`) for improved performance and security.
* Enabled Docker build cache using GitHub Actions cache (`cache-from` and `cache-to`), which speeds up subsequent builds.

**Workflow management:**

* Added `permissions` and `concurrency` settings to restrict workflow permissions and prevent concurrent Docker builds on the same branch.